### PR TITLE
feat: add node key path

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -5,4 +5,4 @@ export NATS_STREAM=mainnet-vaas
 export SERVER_URL=127.0.0.1:7072
 export LOG_LEVEL=info
 export WRITER_BATCH_SIZE="1000"
-
+export NODE_KEY_PATH="./key"

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 var cli struct {
+	NodeKeyPath        string `kong:"optional,env='NODE_KEY_PATH',help='Path to the node key. If set and key doesn't exists there it gets created. If not set, a new key will be generated'"`
 	WormholeEnv        string `kong:"optional,env='WORMHOLE_ENV',help='Wormhole environment (may be \"testnet\" or \"mainnet\") required if WORMHOLE_NETWORK_ID and WORMHOLE_BOOTSTRAP is not set'"`
 	WormholeNetworkID  string `kong:"optional,env='WORMHOLE_NETWORK_ID',help='Wormhole network ID, required if WORMHOLE_ENV is not set'"`
 	WormholeBootstrap  string `kong:"optional,env='WORMHOLE_BOOTSTRAP',help='Bootstrap nodes to connect to. Required if WORMHOLE_ENV is not set'"`
@@ -83,7 +84,7 @@ func main() {
 	}()
 
 	log.Info().Msg("Starting receive/write/serve goroutines")
-	go ReceiveMessages(channel, heartbeat, cli.WormholeEnv, cli.WormholeNetworkID, cli.WormholeBootstrap, cli.WormholeListenPort)
+	go ReceiveMessages(channel, heartbeat, cli.NodeKeyPath, cli.WormholeEnv, cli.WormholeNetworkID, cli.WormholeBootstrap, cli.WormholeListenPort)
 	go WriteMessages(channel, cli.NatsURL, cli.NatsStream, cli.WriterBatchSize)
 	go ServeMessages(cli.ServerURL, cli.NatsURL, cli.NatsStream)
 


### PR DESCRIPTION
this optional env var will use the path to create and store the keypair. Having a single key helps to retain the scores within the network upon crashes/...